### PR TITLE
Index out of bounds exception when combining lists into a map and map.exists("k") always returning false

### DIFF
--- a/src/com/mani/lang/Modules/maps/maps_arraysToMap.java
+++ b/src/com/mani/lang/Modules/maps/maps_arraysToMap.java
@@ -26,7 +26,7 @@ public final class maps_arraysToMap implements ManiCallable {
             System.err.println("Please make sure both arrays are the same size.");
             return "Please make sure both arrays are the same size.";
         }
-        for (int i = 0; i <= first.size(); i++) {
+        for (int i = 0; i < first.size(); i++) {
             joined.put(first.get(i), second.get(i));
         }
         return joined;

--- a/src/com/mani/lang/Modules/maps/maps_mapKeyExists.java
+++ b/src/com/mani/lang/Modules/maps/maps_mapKeyExists.java
@@ -20,7 +20,7 @@ public final class maps_mapKeyExists implements ManiCallable {
         }
         HashMap<Object, Object> given = (HashMap<Object, Object>) arguments.get(0);
         for (Object obj : given.keySet()) {
-            if (obj == arguments.get(1)) {
+            if (obj.equals(arguments.get(1))) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixed issue when combining two lists (of the same size) into a map using map.combine(l1, l2) was causing a java index out of bounds exception.
Fixed issue when map.exists("key") was always returning false, even if the key did exist.