### PR TITLE
Fixed bug with incorrect argument being checked for in map

### DIFF
--- a/src/com/mani/lang/Modules/maps/maps_mapUpdateItem.java
+++ b/src/com/mani/lang/Modules/maps/maps_mapUpdateItem.java
@@ -19,7 +19,7 @@ public final class maps_mapUpdateItem implements ManiCallable {
             return "Please make sure your first argument is a map.";
         }
         HashMap<Object, Object> map = (HashMap<Object, Object>) arguments.get(0);
-        if (map.containsKey(arguments.get(0))) {
+        if (map.containsKey(arguments.get(1))) {
             map.put(arguments.get(1), arguments.get(2));
             return map;
         }


### PR DESCRIPTION
Map updating was checking if map parameter was a key in the map instead of the key passed.