### PR TITLE
Fixed missing libraries when compiling #74

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ task buildCompiler(type: Jar) {
     manifest {
         attributes 'Main-Class': 'com.mani.compiler.ManiCompiler'
     }
+    from {
+        configurations.compile.collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
     with jar
     sourceSets {
         main {


### PR DESCRIPTION
---
Name: Fixed compiler bug #74 
About: When compiling a Máni script which uses third party jars, these were not being included into compiled jar
---

**Is your PR related to a feature request or Bug report?**
If applicable, please list feature request number or bug report ID.
> #74 

**Describe your PR**
A clear and concise description of what your pull request is changing or adding.
> Updated build.gradle to include third party jars into compiled Máni

**Is it in the form of a library**
 - [x] No